### PR TITLE
Fix more_itertools version again

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ packages = find:
 install_requires =
   flake8
   more-itertools<8.11.0; python_version<"3.6"
-  more-itertools; python_version<"3.10"
+  more-itertools!=8.11.0; python_version<"3.10"
   typing; python_version<"3.5"
 
 [options.entry_points]


### PR DESCRIPTION
CI passes on #61 but it fails on master (https://github.com/10sr/flake8-no-implicit-concat/actions/runs/1446743764).
Why????????????????????????????????