### PR TITLE
Remove typing from dependency list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ packages = find:
 install_requires =
   flake8
   more-itertools; python_version<"3.10"
-  typing; python_version<"3.5"
 
 [options.entry_points]
 flake8.extension =


### PR DESCRIPTION
Python >= 3.5 always include this